### PR TITLE
refactor: Change the use of super in getters

### DIFF
--- a/packages/extensions/pubnub/index.ts
+++ b/packages/extensions/pubnub/index.ts
@@ -14,11 +14,8 @@ class PubNubExtension extends SdkExtension {
     this.rc = rc;
   }
 
-  get enabled() {
-    return super.enabled;
-  }
   set enabled(value: boolean) {
-    super.enabled = value;
+    this._enabled = value;
     for (const subscription of this.subscriptions ?? []) {
       subscription.enabled = value;
     }

--- a/packages/extensions/ws/index.ts
+++ b/packages/extensions/ws/index.ts
@@ -51,11 +51,8 @@ class WebSocketExtension extends SdkExtension {
     this.options.autoRecover ??= true;
   }
 
-  get enabled() {
-    return super.enabled;
-  }
   set enabled(value: boolean) {
-    super.enabled = value;
+    this._enabled = value;
     for (const subscription of this.subscriptions ?? []) {
       subscription.enabled = value;
     }


### PR DESCRIPTION
There seems to be an issue with TypeScript with using super in getter/setter functions. This may result in unpredictable problems when compiling down to es5. This MR aims to fix those issues:

* Remove unnecessary getter overrides. Only abstract function are required to be overridden in offsprings. Calling `super.enabled` in getter function is a malpractice in my opinion.
* Replace `super.enabled = value` with `this._enabled=value`. The `_` prefixed properties are not inaccessible to the offsprings, using `super.enabled = value` to run the setter function of the parent is not necessary. 

