### PR TITLE
Update wsTokenExpiresAt logic

### DIFF
--- a/packages/extensions/ws/src/index.ts
+++ b/packages/extensions/ws/src/index.ts
@@ -295,7 +295,7 @@ class WebSocketExtension extends SdkExtension {
   }
 
   async _connect(recoverSession = false) {
-    if (Date.now() > this.wsTokenExpiresAt) {
+    if (!this.wsToken || Date.now() > this.wsTokenExpiresAt) {
       const r = await this.rc.post('/restapi/oauth/wstoken');
       this.wsToken = r.data as WsToken;
       // `expires_in` default value is 600 seconds. That's why we `* 0.8`

--- a/packages/extensions/ws/src/index.ts
+++ b/packages/extensions/ws/src/index.ts
@@ -298,6 +298,7 @@ class WebSocketExtension extends SdkExtension {
     if (Date.now() > this.wsTokenExpiresAt) {
       const r = await this.rc.post('/restapi/oauth/wstoken');
       this.wsToken = r.data as WsToken;
+      // `expires_in` default value is 600 seconds. That's why we `* 0.8`
       this.wsTokenExpiresAt = Date.now() + (this.wsToken.expires_in * 0.8) * 1000;
     }
     let wsUri = `${this.wsToken!.uri}?access_token=${this.wsToken!.ws_access_token}`;

--- a/packages/extensions/ws/src/index.ts
+++ b/packages/extensions/ws/src/index.ts
@@ -298,14 +298,11 @@ class WebSocketExtension extends SdkExtension {
     if (Date.now() > this.wsTokenExpiresAt) {
       const r = await this.rc.post('/restapi/oauth/wstoken');
       this.wsToken = r.data as WsToken;
-      this.wsTokenExpiresAt = Date.now() + (this.wsToken.expires_in - 10) * 1000;
+      this.wsTokenExpiresAt = Date.now() + (this.wsToken.expires_in * 0.8) * 1000;
     }
-    let wsUri = '';
-    if (this.wsToken) {
-      wsUri = `${this.wsToken.uri}?access_token=${this.wsToken.ws_access_token}`;
-      if (recoverSession && this.wsc) {
-        wsUri += `&wsc=${this.wsc.token}`;
-      }
+    let wsUri = `${this.wsToken!.uri}?access_token=${this.wsToken!.ws_access_token}`;
+    if (recoverSession && this.wsc) {
+      wsUri += `&wsc=${this.wsc.token}`;
     }
     this.ws = new WS(wsUri);
     this.eventEmitter.emit(Events.newWebSocketObject, this.ws);


### PR DESCRIPTION
Because the expires_in by default is 600 seconds (10 minutes).

`-10` is too small to cover network slowness. I changed it to `* 0.8`.

I made this change due to a recent ws-token expired issue. Just to make sure that we never use a expired ws token to connect to WS server.

I also removed `if (this.wsToken) {`, becuase it is always true.