### PR TITLE
fix(ws): [misc] fix "WebSocket is already in CLOSING or CLOSED state" on pinging server

### DIFF
--- a/packages/extensions/ws/src/index.ts
+++ b/packages/extensions/ws/src/index.ts
@@ -259,13 +259,16 @@ class WebSocketExtension extends SdkExtension {
     if (this.options.autoRecover?.enabled !== true) {
       return;
     }
+    if (this.ws?.readyState !== OPEN) {
+      return;
+    }
     try {
-      if (this.ws?.ping) {
+      if (this.ws.ping) {
         // node.js
-        this.ws?.ping();
+        this.ws.ping();
       } else {
         // browser
-        await this.ws?.send(
+        await this.ws.send(
           JSON.stringify([
             {
               type: 'Heartbeat',
@@ -275,7 +278,7 @@ class WebSocketExtension extends SdkExtension {
         );
       }
     } catch (e) {
-      this.ws?.close(); // Explicitly mark WS as closed
+      this.ws.close(); // Explicitly mark WS as closed
     }
   }
 


### PR DESCRIPTION
Found an error occured on sending ping message to server. 

``` js
16:54:22.759  ==== Sleep Detected =====
16:54:22.810  WebSocket is already in CLOSING or CLOSED state.
ws.send @ commons.js:2
pingServer @ commons.js:2
(anonymous) @ commons.js:2
r @ commons.js:2
setTimeout (async)
(anonymous) @ commons.js:2
(anonymous) @ commons.js:2
r @ commons.js:2
```

![image_2023_9_12_16_59_26](https://github.com/ringcentral/ringcentral-extensible/assets/907369/02e2c7c2-1b40-40d9-89df-f917b9dac378)

